### PR TITLE
ci(windows-release): use windows-latest instead of retired windows-2019

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -51,7 +51,7 @@ jobs:
         include:
           - os: ubuntu-latest
             artifact_name: 'release/{*.AppImage,*.rpm,*.deb,*.yml}'
-          - os: windows-2019
+          - os: windows-latest
             artifact_name: 'release/{*.msi,*.exe,*.blockmap,*.yml}'
           - os: macos-latest
             artifact_name: 'release/{*.dmg,*.blockmap,*.yml}'


### PR DESCRIPTION
Windows Server 2019 has been retired. The Windows Server 2019 image has been removed as of 2025-06-30. For more details, see https://github.com/actions/runner-images/issues/12045