### PR TITLE
ci(release): use softprops/action-gh-release instead of actions/create-release

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -30,16 +30,16 @@ jobs:
           echo "link=$LINK" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
-        uses: actions/create-release@v1.1.4
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.vars.outputs.version }}
-          release_name: ${{ steps.vars.outputs.version }}
+          name: ${{ steps.vars.outputs.version }}
           draft: true
           prerelease: false
           body: |
             See the changes in [CHANGELOG.md](${{ steps.changelog.outputs.link }}).
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   release:
     name: EchoScreen Multi-Platform Build

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ steps.vars.outputs.version }}
           name: ${{ steps.vars.outputs.version }}
@@ -38,8 +40,6 @@ jobs:
           prerelease: false
           body: |
             See the changes in [CHANGELOG.md](${{ steps.changelog.outputs.link }}).
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   release:
     name: EchoScreen Multi-Platform Build


### PR DESCRIPTION
[Create GitHub Release](https://github.com/rozsazoltan/echoscreen/actions/runs/16187066477/job/45694625631#annotation:5:14)
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

> Please note: This repository is currently unmaintained by a team of developers at GitHub. The repository is here and you can use it as an example, or in Actions. However please be aware that we are not going to be updating issues or pull requests on this repository.

* https://github.com/actions/create-release

Alternative:
* [softprops/action-gh-release](https://github.com/softprops/action-gh-release)